### PR TITLE
Merging options fails when no parameters set for run() method.

### DIFF
--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -81,7 +81,7 @@ Webtask.prototype.run = function (options, cb) {
         'delete': 'del',
     };
     var urlData = Url.parse(this.url, true);
-    var config = defaultsDeep(options, {
+    var config = defaultsDeep(options || {}, {
         method: 'get',
         path: '',
         query: {},


### PR DESCRIPTION
Executing `new sandbox.Webtask(profile, token).run()` results in:

> TypeError: Cannot read property 'method' of undefined

![image](https://cloud.githubusercontent.com/assets/502493/14092756/693ae17c-f549-11e5-990e-ec2620011bdb.png)

This one works: `run({})` when executing against an empty Object.