### PR TITLE
Support issuing webtask tokens associated with custom domain

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -149,6 +149,8 @@ Sandbox.prototype.createToken = function (options, cb) {
             return reject('The `nbf` parameter cannot be set to a later time than `exp`.');
         }
 
+        if (options.host)
+            params.host = options.host;
         if (options.code_url)
             params.url = options.code_url;
         if (options.code)

--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -49,7 +49,7 @@ function Webtask (sandbox, token) {
             var url;
             if (this.claims.host) {
                var surl = Url.parse(this.sandbox.url);
-               url = surl.protocol + '//' + this.claims.host + (surl.port ? (':' + surl.port) : '') '/' + this.sandbox.container;
+               url = surl.protocol + '//' + this.claims.host + (surl.port ? (':' + surl.port) : '') + '/' + this.sandbox.container;
             }
             else {
                url = this.sandbox.url + '/api/run/' + this.sandbox.container;

--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -46,7 +46,14 @@ function Webtask (sandbox, token) {
     Object.defineProperty(this, 'url', {
         enumerable: true,
         get: function () {
-            var url = this.sandbox.url + '/api/run/' + this.sandbox.container;
+            var url;
+            if (this.claims.host) {
+               var surl = Url.parse(this.sandbox.url);
+               url = surl.protocol + '//' + this.claims.host + (surl.port ? (':' + surl.port) : '') '/' + this.sandbox.container;
+            }
+            else {
+               url = this.sandbox.url + '/api/run/' + this.sandbox.container;
+            }
 
             if (this.claims.jtn) url += '/' + this.claims.jtn;
             else url += '?key=' + this.token;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxjs",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Sandbox node.js code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This enables requesting issuance of webtask tokens with the `host` claim that indicates the custom domain name over which this webtask can be invoked. 

If a named webtask can normally be called at

```
https://webtask.it.auth0.com/api/run/foo/bar/baz
```

and the underlying webtask token has the `host` claim set to the `serverless.host` domain name, then the same webtask can also be called over 

```
https://serverless.host/foo/bar/baz
```

**NOTE** the `/api/run` part of the URL path is missing as it is implied when custom domain names are used.