### PR TITLE
Metadata support

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -163,6 +163,8 @@ Sandbox.prototype.createToken = function (options, cb) {
             params.pctx = options.params;
         if (options.param && Object.keys(options.param).length > 0)
             params.pctx = options.param;
+        if (options.meta && Object.keys(options.meta).length > 0)
+            params.meta = options.meta;
         if (options.nbf !== undefined)
             params.nbf = options.nbf;
         if (options.exp !== undefined)
@@ -335,7 +337,7 @@ Sandbox.prototype.removeWebtask = function (options, cb) {
  */
 Sandbox.prototype.listWebtasks = function (options, cb) {
     if (!options) options = {};
-    
+
     var url = this.url + '/api/webtask/'
         + (options.container || this.container);
     var request = Superagent
@@ -345,12 +347,17 @@ Sandbox.prototype.listWebtasks = function (options, cb) {
 
     if (options.offset) request.query({ offset: options.offset });
     if (options.limit) request.query({ limit: options.limit });
+    if (options.meta) {
+        for (var m in options.meta) {
+            request.query({ meta: m + ':' + options.meta[m] });
+        }
+    }
 
     var self = this;
     var promise = Request(request)
         .get('body')
         .map(function (webtask) {
-            return new Webtask(self, webtask.token);
+            return new Webtask(self, webtask.token, webtask.meta);
         });
 
     return cb ? promise.nodeify(cb) : promise;
@@ -364,6 +371,7 @@ Sandbox.prototype.listWebtasks = function (options, cb) {
  * @param {String} options.name - The name of the cron job.
  * @param {String} options.token - The webtask token that will be used to run the job.
  * @param {String} options.schedule - The cron schedule that will be used to determine when the job will be run.
+ * @param {String} options.meta - The cron metadata (set of string key value pairs).
  * @param {Function} [cb] - Optional callback function for node-style callbacks.
  * @returns {Promise} A Promise that will be fulfilled with a {@see CronJob} instance.
  */
@@ -377,6 +385,9 @@ Sandbox.prototype.createCronJob = function (options, cb) {
     
     if (options.state) {
         payload.state = options.state;
+    }
+    if (options.meta) {
+        payload.meta = options.meta;
     }
 
     var request = Superagent
@@ -467,6 +478,11 @@ Sandbox.prototype.listCronJobs = function (options, cb) {
 
     if (options.offset) request.query({ offset: options.offset });
     if (options.limit) request.query({ limit: options.limit });
+    if (options.meta) {
+        for (var m in options.meta) {
+            request.query({ meta: m + ':' + options.meta[m] });
+        }
+    }
 
     var promise = Request(request)
         .get('body')

--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -14,7 +14,7 @@ var getFrom = require('lodash.get');
  *
  * @constructor
  */
-function Webtask (sandbox, token) {
+function Webtask (sandbox, token, meta) {
     /**
      * @property claims - The claims embedded in the Webtask's token
      */
@@ -29,6 +29,11 @@ function Webtask (sandbox, token) {
      * @property token - The token associated with this webtask
      */
     this.token = token;
+
+    /**
+     * @property meta - The metadata associated with this webtask
+     */
+    this.meta = meta;
 
     /**
      * @property container - The container name in which the webtask will run
@@ -140,6 +145,7 @@ Webtask.prototype.createCronJob = function (options, cb) {
     options = defaultsDeep(options, {
         name: this.claims.jtn || filename,
         state: 'active',
+        meta: this.meta,
     });
     
     if (!options.name) throw new Error('Cron jobs must have a name.');
@@ -149,6 +155,7 @@ Webtask.prototype.createCronJob = function (options, cb) {
         token: this.token,
         schedule: options.schedule,
         state: options.state,
+        meta: options.meta
     });
     
     return cb ? promise.nodeify(cb, {spread: true}) : promise;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxjs",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Sandbox node.js code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This adds support for specifying metadata when creating named webtasks or cron jobs, and specifying metadata filters when listing named webtasks or cron jobs.