### PR TITLE
Implement Sandbox#clone

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -30,6 +30,7 @@ module.exports.PARSE_ON_ARITY = 2;
  * @param {String} options.url - The url of the webtask cluster where code will run
  * @param {String} options.container - The name of the container in which code will run
  * @param {String} options.token - The JWT (see: http://jwt.io) issued by webtask.io that grants rights to run code in the indicated container
+ * @param {String} [options.onBeforeRequest] - An array of hook functions to be invoked with a prepared request
  */
 function Sandbox (options) {
     this.url = options.url;
@@ -39,6 +40,24 @@ function Sandbox (options) {
         .concat(options.onBeforeRequest)
         .filter(hook => typeof hook === 'function');
 }
+
+/**
+ * Create a clone of this sandbox instances with one or more different parameters
+ *
+ * @param {Object} options - Options used to configure the profile
+ * @param {String} [options.url] - The url of the webtask cluster where code will run
+ * @param {String} [options.container] - The name of the container in which code will run
+ * @param {String} [options.token] - The JWT (see: http://jwt.io) issued by webtask.io that grants rights to run code in the indicated container
+ * @param {String} [options.onBeforeRequest] - An array of hook functions to be invoked with a prepared request
+ */
+Sandbox.prototype.clone = function (options) {
+    return new Sandbox({
+        url: options.url || this.url,
+        container: options.container || this.container,
+        token: options.token || this.token,
+        onBeforeRequest: options.onBeforeRequest || this.onBeforeRequest,
+    });
+};
 
 /**
  * Create a Webtask from the given options


### PR DESCRIPTION
- Implement `Sandbox#clone`. This api makes it easy to clone a `Sandbox` instances while changing the sandbox's configuration.