### PR TITLE
security v2: support for token-less webtasks, 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Sandbox node.js code.
             * [.createTokenRaw(claims, [options], [cb])](#module_sandboxjs..Sandbox+createTokenRaw) ⇒ <code>Promise</code>
             * [.createLogStream(options)](#module_sandboxjs..Sandbox+createLogStream) ⇒ <code>Stream</code>
             * [.getWebtask(options, [cb])](#module_sandboxjs..Sandbox+getWebtask) ⇒ <code>Promise</code>
+            * [.createWebtask(options, [cb])](#module_sandboxjs..Sandbox+createWebtask) ⇒ <code>Promise</code>
             * [.removeWebtask(options, [cb])](#module_sandboxjs..Sandbox+removeWebtask) ⇒ <code>Promise</code>
             * [.updateWebtask(options, [cb])](#module_sandboxjs..Sandbox+updateWebtask) ⇒ <code>Promise</code>
             * [.listWebtasks(options, [cb])](#module_sandboxjs..Sandbox+listWebtasks) ⇒ <code>Promise</code>
@@ -214,6 +215,7 @@ Create a Sandbox instance
     * [.createTokenRaw(claims, [options], [cb])](#module_sandboxjs..Sandbox+createTokenRaw) ⇒ <code>Promise</code>
     * [.createLogStream(options)](#module_sandboxjs..Sandbox+createLogStream) ⇒ <code>Stream</code>
     * [.getWebtask(options, [cb])](#module_sandboxjs..Sandbox+getWebtask) ⇒ <code>Promise</code>
+    * [.createWebtask(options, [cb])](#module_sandboxjs..Sandbox+createWebtask) ⇒ <code>Promise</code>
     * [.removeWebtask(options, [cb])](#module_sandboxjs..Sandbox+removeWebtask) ⇒ <code>Promise</code>
     * [.updateWebtask(options, [cb])](#module_sandboxjs..Sandbox+updateWebtask) ⇒ <code>Promise</code>
     * [.listWebtasks(options, [cb])](#module_sandboxjs..Sandbox+listWebtasks) ⇒ <code>Promise</code>
@@ -388,6 +390,24 @@ Read a named webtask
 | options.name | <code>String</code> | The name of the webtask. |
 | [cb] | <code>function</code> | Optional callback function for node-style callbacks. |
 
+<a name="module_sandboxjs..Sandbox+createWebtask"></a>
+
+#### sandbox.createWebtask(options, [cb]) ⇒ <code>Promise</code>
+Create a named webtask
+
+**Kind**: instance method of <code>[Sandbox](#module_sandboxjs..Sandbox)</code>  
+**Returns**: <code>Promise</code> - A Promise that will be fulfilled with an array of Webtasks  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>Object</code> | Options |
+| [options.container] | <code>String</code> | Set the webtask container. Defaults to the profile's container. |
+| options.name | <code>String</code> | The name of the webtask. |
+| [options.secrets] | <code>String</code> | Set the webtask secrets. |
+| [options.meta] | <code>String</code> | Set the webtask metadata. |
+| [options.host] | <code>String</code> | Set the webtask hostname. |
+| [cb] | <code>function</code> | Optional callback function for node-style callbacks. |
+
 <a name="module_sandboxjs..Sandbox+removeWebtask"></a>
 
 #### sandbox.removeWebtask(options, [cb]) ⇒ <code>Promise</code>
@@ -444,7 +464,7 @@ List named webtasks from the webtask container
 <a name="module_sandboxjs..Sandbox+createCronJob"></a>
 
 #### sandbox.createCronJob(options, [cb]) ⇒ <code>Promise</code>
-Create a cron job from an already-existing webtask token
+Create a cron job from an already-existing webtask
 
 **Kind**: instance method of <code>[Sandbox](#module_sandboxjs..Sandbox)</code>  
 **Returns**: <code>Promise</code> - A Promise that will be fulfilled with a {@see CronJob} instance.  
@@ -454,7 +474,7 @@ Create a cron job from an already-existing webtask token
 | options | <code>Object</code> | Options for creating a cron job |
 | [options.container] | <code>String</code> | The container in which the job will run. Defaults to the current profile's container. |
 | options.name | <code>String</code> | The name of the cron job. |
-| options.token | <code>String</code> | The webtask token that will be used to run the job. |
+| [options.token] | <code>String</code> | The webtask token that will be used to run the job. |
 | options.schedule | <code>String</code> | The cron schedule that will be used to determine when the job will be run. |
 | options.tz | <code>String</code> | The cron timezone (IANA timezone). |
 | options.meta | <code>String</code> | The cron metadata (set of string key value pairs). |
@@ -652,7 +672,6 @@ Read the storage associated to the a webtask
 
 * [CronJob](#CronJob)
     * [new CronJob()](#new_CronJob_new)
-    * [.claims](#CronJob+claims)
     * [.sandbox](#CronJob+sandbox)
     * [.refresh([cb])](#CronJob+refresh) ⇒ <code>Promise</code>
     * [.remove([cb])](#CronJob+remove) ⇒ <code>Promise</code>
@@ -664,16 +683,6 @@ Read the storage associated to the a webtask
 
 ### new CronJob()
 Creates an object representing a CronJob
-
-<a name="CronJob+claims"></a>
-
-### cronJob.claims
-**Kind**: instance property of <code>[CronJob](#CronJob)</code>  
-**Properties**
-
-| Name | Description |
-| --- | --- |
-| claims | The claims embedded in the Webtask's token |
 
 <a name="CronJob+sandbox"></a>
 
@@ -763,8 +772,8 @@ Set the cron job's state
 * [Webtask](#Webtask)
     * [new Webtask()](#new_Webtask_new)
     * [.claims](#Webtask+claims)
-    * [.sandbox](#Webtask+sandbox)
     * [.token](#Webtask+token)
+    * [.sandbox](#Webtask+sandbox)
     * [.meta](#Webtask+meta)
     * [.createLogStream(options)](#Webtask+createLogStream) ⇒ <code>Stream</code>
     * [.run(options, [cb])](#Webtask+run) ⇒ <code>Promise</code>
@@ -791,16 +800,6 @@ Creates an object representing a Webtask
 | --- | --- |
 | claims | The claims embedded in the Webtask's token |
 
-<a name="Webtask+sandbox"></a>
-
-### webtask.sandbox
-**Kind**: instance property of <code>[Webtask](#Webtask)</code>  
-**Properties**
-
-| Name | Description |
-| --- | --- |
-| sandbox | The {@see Sandbox} instance used to create this Webtask instance |
-
 <a name="Webtask+token"></a>
 
 ### webtask.token
@@ -810,6 +809,16 @@ Creates an object representing a Webtask
 | Name | Description |
 | --- | --- |
 | token | The token associated with this webtask |
+
+<a name="Webtask+sandbox"></a>
+
+### webtask.sandbox
+**Kind**: instance property of <code>[Webtask](#Webtask)</code>  
+**Properties**
+
+| Name | Description |
+| --- | --- |
+| sandbox | The {@see Sandbox} instance used to create this Webtask instance |
 
 <a name="Webtask+meta"></a>
 

--- a/lib/cronJob.js
+++ b/lib/cronJob.js
@@ -23,7 +23,15 @@ function CronJob (sandbox, job) {
     /**
      * @property claims - The claims embedded in the Webtask's token
      */
-    this.claims = Decode(job.token);
+    if (job.token) {
+        this.claims = Decode(job.token);
+    }
+    else {
+        this.claims = {
+            jtn: job.name,
+            ten: this.container,
+        };
+    }
 
     /**
      * @property sandbox - The {@see Sandbox} instance used to create this Webtask instance

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -355,6 +355,77 @@ Sandbox.prototype.getWebtask = function (options, cb) {
 };
 
 /**
+ * Create a named webtask 
+ *
+ * @param {Object} options - Options
+ * @param {String} [options.container] - Set the webtask container. Defaults to the profile's container.
+ * @param {String} options.name - The name of the webtask.
+ * @param {String} [options.secrets] - Set the webtask secrets. 
+ * @param {String} [options.meta] - Set the webtask metadata.
+ * @param {String} [options.host] - Set the webtask hostname.  
+ * @param {Function} [cb] - Optional callback function for node-style callbacks.
+ * @return {Promise} A Promise that will be fulfilled with an array of Webtasks
+ */
+Sandbox.prototype.createWebtask = function (options, cb) {
+    if (!options) options = {};
+
+    var promise;
+    var err;
+
+    if (typeof options.name !== 'string') {
+        err = new Error('The `name` option is required and must be a string');
+        err.statusCode = 400;
+
+        promise = Bluebird.reject(err);
+    }
+
+    if (options.code && typeof options.code !== 'string') {
+        err = new Error('The `code` option must be a string');
+        err.statusCode = 400;
+
+        promise = Bluebird.reject(err);
+    }
+
+    if (options.url && typeof options.url !== 'string') {
+        err = new Error('The `url` option must be a string');
+        err.statusCode = 400;
+
+        promise = Bluebird.reject(err);
+    }
+
+    if (options.code && options.url) {
+        err = new Error('Either the `code` or `url` option can be specified, but not both');
+        err.statusCode = 400;
+
+        promise = Bluebird.reject(err);
+    }
+
+    if (!err) {
+        var url = this.url + '/api/webtask/'
+            + (options.container || this.container) + '/' + options.name;
+        var payload = {};
+        if (options.secrets) payload.secrets = options.secrets;
+        if (options.code) payload.code = options.code;
+        if (options.url) payload.url = options.url;
+        if (options.meta) payload.meta = options.meta;
+        if (options.host) payload.host = options.host;
+        var request = Superagent
+            .put(url)
+            .set('Authorization', 'Bearer ' + this.token)
+            .send(payload)
+
+        var self = this;
+        promise = this.issueRequest(request)
+            .then(function (res) {
+                return new Webtask(self, res.body.token || res.body.name, { container: options.container || self.container, meta: res.body.meta, webtask_url: res.body.webtask_url });
+            });
+    }
+
+    return cb ? promise.nodeify(cb) : promise;
+};
+
+
+/**
  * Remove a named webtask from the webtask container
  *
  * @param {Object} options - Options
@@ -527,19 +598,19 @@ Sandbox.prototype.listWebtasks = function (options, cb) {
     var promise = this.issueRequest(request)
         .get('body')
         .map(function (webtask) {
-            return new Webtask(self, webtask.token, { meta: webtask.meta, webtask_url: webtask.webtask_url });
+            return new Webtask(self, webtask.token || webtask.name, { meta: webtask.meta, webtask_url: webtask.webtask_url });
         });
 
     return cb ? promise.nodeify(cb) : promise;
 };
 
 /**
- * Create a cron job from an already-existing webtask token
+ * Create a cron job from an already-existing webtask
  *
  * @param {Object} options - Options for creating a cron job
  * @param {String} [options.container] - The container in which the job will run. Defaults to the current profile's container.
  * @param {String} options.name - The name of the cron job.
- * @param {String} options.token - The webtask token that will be used to run the job.
+ * @param {String} [options.token] - The webtask token that will be used to run the job.
  * @param {String} options.schedule - The cron schedule that will be used to determine when the job will be run.
  * @param {String} options.tz - The cron timezone (IANA timezone).
  * @param {String} options.meta - The cron metadata (set of string key value pairs).
@@ -550,9 +621,9 @@ Sandbox.prototype.createCronJob = function (options, cb) {
     options = defaults(options, { container: this.container });
 
     var payload = {
-        token: options.token,
         schedule: options.schedule,
     };
+    if (options.token) payload.token = options.token;
 
     if (options.state) {
         payload.state = options.state;

--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -14,23 +14,31 @@ var getFrom = require('lodash.get');
  *
  * @constructor
  */
-function Webtask (sandbox, token, options) {
+function Webtask (sandbox, tokenOrName, options) {
     if (!options) options = {};
 
-    /**
-     * @property claims - The claims embedded in the Webtask's token
-     */
-    this.claims = Decode(token);
+    try {
+        /**
+         * @property claims - The claims embedded in the Webtask's token
+         */
+        this.claims = Decode(tokenOrName);
+        /**
+         * @property token - The token associated with this webtask
+         */
+        this.token = tokenOrName;
+    }
+    catch (_) {
+        if (typeof tokenOrName !== 'string') throw new Error('tokenOrName must be a string');
+        this.claims = {
+            jtn: tokenOrName,
+            ten: options.container || sandbox.container,
+        };
+    }
 
     /**
      * @property sandbox - The {@see Sandbox} instance used to create this Webtask instance
      */
     this.sandbox = sandbox;
-
-    /**
-     * @property token - The token associated with this webtask
-     */
-    this.token = token;
 
     /**
      * @property meta - The metadata associated with this webtask
@@ -145,16 +153,28 @@ Webtask.prototype.run = function (options, cb) {
  * @returns {Promise} - A Promise that will be resolved with a {@see CronJob} instance.
  */
 Webtask.prototype.createCronJob = function (options, cb) {
-    var parsedUrl = Url.parse(this.claims.url);
-    var filename = parsedUrl.pathname
-        ?   Path.basename(parsedUrl.pathname)
-        :   '';
+    if (this.token) {
+        var parsedUrl = Url.parse(this.claims.url);
+        var filename = parsedUrl.pathname
+            ?   Path.basename(parsedUrl.pathname)
+            :   '';
 
-    options = defaultsDeep(options, {
-        name: this.claims.jtn || filename,
-        state: 'active',
-        meta: this.meta,
-    });
+        options = defaultsDeep(options, {
+            name: this.claims.jtn || filename,
+            state: 'active',
+            meta: this.meta,
+        });
+    }
+    else {
+        if (options.name && options.name !== this.claims.jtn) {
+            throw new Error('Server does not support specifying CRON name that is different from webtask name.');
+        }
+        options = defaultsDeep(options, {
+            name: this.claims.jtn,
+            state: 'active',
+            meta: this.meta,
+        });        
+    }
 
     if (!options.name) throw new Error('Cron jobs must have a name.');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxjs",
-  "version": "3.8.0",
+  "version": "4.0.0",
   "description": "Sandbox node.js code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This contains the minimal set of changes necessary to make auth v2 access tokens work with sandboxjs. Changes are supposed to be backwards compatible. Key changes:

1. V2 access token can now be used to authorize management API calls in addition to WT token. 
2. Added createWebtask API as a facade over PUT /api/webtask/{container}
3. CronJob class now allows creation of cron jobs without specifying the underlying token. It is assumed a named webtask with the same name as the cron job pre-exists. 
4. Webtask class constuctor now allows specifying either the underlying webtask token (v1) or the name of name of the named webtask. 