### PR TITLE
Fix blank code creation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,11 +6,4 @@ module.exports = {
         "node": true,
     },
     "extends": "eslint:recommended",
-    "rules": {
-       "indent": ["warn", 4],
-       "global-require": 0,
-       "camelcase": 0,
-       "curly": 0,
-       "no-undef": ["error"],
-    }
 }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -71,7 +71,9 @@ Sandbox.prototype.create = function (codeOrUrl, options, cb) {
     if (typeof codeOrUrl !== 'string') {
         cb = options;
         options = codeOrUrl;
-        codeOrUrl = options.code || options.code_url;
+        codeOrUrl = typeof options.code === 'string'
+            ? options.code
+            : options.code_url;
     }
 
     if (typeof options === 'function') {
@@ -181,7 +183,7 @@ Sandbox.prototype.createToken = function (options, cb) {
             params.host = options.host;
         if (options.code_url)
             params.url = options.code_url;
-        if (options.code)
+        if (typeof options.code === 'string')
             params.code = options.code;
         if (options.secrets && Object.keys(options.secrets).length > 0)
             params.ectx = options.secrets;

--- a/test/execution.js
+++ b/test/execution.js
@@ -43,7 +43,7 @@ lab.experiment('Sandbox instance', {parallel: false, timeout: 10000}, function (
                 expect(webtask.container).to.equal(sandbox.container);
                 expect(webtask.token).to.be.a.string();
                 expect(webtask.url).to.be.a.string();
-                expect(webtask.url).to.match(/^https:\/\//);
+                expect(webtask.url).to.match(/^https?:\/\//);
             })
             .nodeify(done);
     });
@@ -60,7 +60,7 @@ lab.experiment('Sandbox instance', {parallel: false, timeout: 10000}, function (
             expect(webtask.container).to.equal(sandbox.container);
             expect(webtask.token).to.be.a.string();
             expect(webtask.url).to.be.a.string();
-            expect(webtask.url).to.match(/^https:\/\//);
+            expect(webtask.url).to.match(/^https?:\/\//);
 
             done(err);
         });
@@ -82,8 +82,8 @@ lab.experiment('Sandbox instance', {parallel: false, timeout: 10000}, function (
                 onCleanUp(next => webtask1.remove(next));
                 onCleanUp(next => webtask2.remove(next));
 
-                expect(webtask1.url).to.match(/^https:\/\//);
-                expect(webtask2.url).to.match(/^https:\/\//);
+                expect(webtask1.url).to.match(/^https?:\/\//);
+                expect(webtask2.url).to.match(/^https?:\/\//);
                 expect(url1.query.key).to.be.a.string();
                 expect(url2.query.key).to.not.exist();
             })

--- a/test/webtask.js
+++ b/test/webtask.js
@@ -191,4 +191,23 @@ lab.experiment('Webtask instances', { parallel: false, timeout: 10000 }, functio
             })
             .nodeify(done);
     });
+
+    lab.test('can be used to create a webtask having an empty string as code', (done, onCleanUp) => {
+        var sandbox = Sandbox.init(sandboxParams);
+
+        sandbox.create({
+            code: '',
+            name: 'create-empty-code',
+        })
+            .tap(webtask => {
+                onCleanUp(next => void webtask.remove(next));
+
+                return webtask.inspect({ decrypt: true, fetch_code: true, meta: true })
+                    .tap(inspection => {
+                        expect(inspection.code).to.equal('');
+                        expect(inspection.jtn).to.equal(webtask.claims.jtn);
+                    });
+            })
+            .nodeify(done);
+    });
 });


### PR DESCRIPTION
- Supports creating named webtasks having code that is a blank string
- Removes eslint custom rules
- Relaxes url regexes in tests to support running against a local, http webtask instance