### PR TITLE
Support for webtask inspection APIs with security v2, 4.2.0

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -350,11 +350,10 @@ Sandbox.prototype.getWebtask = function (options, cb) {
 
         if (options.decrypt) request.query({ decrypt: options.decrypt });
         if (options.fetch_code) request.query({ fetch_code: options.fetch_code });
-
         promise = this.issueRequest(request)
             .get('body')
             .then(function (data) {
-                return new Webtask(self, data.token, { secrets: data.secrets, code: data.code, meta: data.meta, webtask_url: data.webtask_url });
+                return new Webtask(self, data.token || data.name, { secrets: data.secrets, code: data.code, meta: data.meta, webtask_url: data.webtask_url });
             });
     }
 
@@ -857,7 +856,7 @@ Sandbox.prototype.inspectToken = function (options, cb) {
 Sandbox.prototype.inspectWebtask = function (options, cb) {
     options = defaults(options, { container: this.container });
 
-    var promise = this.getWebtask({ name: options.name })
+    var promise = this.getWebtask(options)
         .call('inspect', { decrypt: options.decrypt, fetch_code: options.fetch_code, meta: options.meta });
 
     return cb ? promise.nodeify(cb) : promise;

--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -211,9 +211,15 @@ Webtask.prototype.createCronJob = function (options, cb) {
  * @returns {Promise} A Promise that will be fulfilled with the result of inspecting the token.
  */
 Webtask.prototype.inspect = function (options, cb) {
-    options.token = this.token;
+    var promise;
 
-    var promise = this.sandbox.inspectToken(options);
+    if (this.token) {
+        options.token = this.token;
+        promise = this.sandbox.inspectToken(options);
+    }
+    else {
+        promise = Promise.resolve(this);
+    }
 
     return cb ? promise.nodeify(cb) : promise;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxjs",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Sandbox node.js code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The inspectWebtask API will return the Webtask instance instead of the token when security v2 is used. This is driven by changes in wt-cli.