### PR TITLE
fix webtask.inspect for sec v2

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -871,8 +871,10 @@ Sandbox.prototype.inspectToken = function (options, cb) {
 Sandbox.prototype.inspectWebtask = function (options, cb) {
     options = defaults(options, { container: this.container });
 
-    var promise = this.getWebtask({ name: options.name })
-        .call('inspect', { decrypt: options.decrypt, fetch_code: options.fetch_code, meta: options.meta });
+    var promise = this.securityVersion === 'v2'
+        ? this.getWebtask({ name: options.name, decrypt: options.decrypt, fetch_code: options.fetch_code })
+        : this.getWebtask({ name: options.name })
+            .call('inspect', { decrypt: options.decrypt, fetch_code: options.fetch_code, meta: options.meta });
 
     return cb ? promise.nodeify(cb) : promise;
 };

--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -222,7 +222,7 @@ Webtask.prototype.createCronJob = function (options, cb) {
  */
 Webtask.prototype.inspect = function (options, cb) {
     if (this.sandbox.securityVersion === 'v2') {
-        return cb ? cb(null, this) : Bluebird.resolve(this);
+        throw new Error('The Webtask.inspect function is not supported in the current configuration. Consider using Sandbox.inspectWebtask instead.')
     }
 
     options.token = this.token;

--- a/lib/webtask.js
+++ b/lib/webtask.js
@@ -221,6 +221,10 @@ Webtask.prototype.createCronJob = function (options, cb) {
  * @returns {Promise} A Promise that will be fulfilled with the result of inspecting the token.
  */
 Webtask.prototype.inspect = function (options, cb) {
+    if (this.sandbox.securityVersion === 'v2') {
+        return cb ? cb(null, this) : Bluebird.resolve(this);
+    }
+
     options.token = this.token;
 
     var promise = this.sandbox.inspectToken(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxjs",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Sandbox node.js code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Webtask.inspect returns self in security v2 instead of attempting to call /api/tokens/inspect on the non-existing token, which fails. 