### PR TITLE
Update default url for webtask cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Create a Sandbox instance from a webtask token
 | --- | --- | --- |
 | token | <code>String</code> | The webtask token from which the Sandbox profile will be derived. |
 | options | <code>Object</code> | The options for creating the Sandbox instance that override the derived values from the token. |
-| [options.url] | <code>String</code> | The url of the webtask cluster. Defaults to the public 'webtask.it.auth0.com' cluster. |
+| [options.url] | <code>String</code> | The url of the webtask cluster. Defaults to the public 'sandbox.auth0-extend.com' cluster. |
 | options.container | <code>String</code> | The container with which this Sandbox instance should be associated. Note that your Webtask token must give you access to that container or all operations will fail. |
 | options.token | <code>String</code> | The Webtask Token. See: https://webtask.io/docs/api_issue. |
 
@@ -194,7 +194,7 @@ Create a Sandbox instance
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> | The options for creating the Sandbox instance. |
-| [options.url] | <code>String</code> | The url of the webtask cluster. Defaults to the public 'webtask.it.auth0.com' cluster. |
+| [options.url] | <code>String</code> | The url of the webtask cluster. Defaults to the public 'sandbox.auth0-extend.com' cluster. |
 | options.container | <code>String</code> | The container with which this Sandbox instance should be associated. Note that your Webtask token must give you access to that container or all operations will fail. |
 | options.token | <code>String</code> | The Webtask Token. See: https://webtask.io/docs/api_issue. |
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ interface SandboxOptions {
      */
     container: string,
     /**
-     * [optional] The URL of the webtask cluster. Defaults to the public 'webtask.it.auth0.com' cluster.
+     * [optional] The URL of the webtask cluster. Defaults to the public 'sandbox.auth0-extend.com' cluster.
      */
     url?: string
   }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1051,7 +1051,7 @@ Sandbox.limits = {
  *
  * @param {String} token - The webtask token from which the Sandbox profile will be derived.
  * @param {Object} options - The options for creating the Sandbox instance that override the derived values from the token.
- * @param {String} [options.url] - The url of the webtask cluster. Defaults to the public 'webtask.it.auth0.com' cluster.
+ * @param {String} [options.url] - The url of the webtask cluster. Defaults to the public 'sandbox.auth0-extend.com' cluster.
  * @param {String} options.container - The container with which this Sandbox instance should be associated. Note that your Webtask token must give you access to that container or all operations will fail.
  * @param {String} options.token - The Webtask Token. See: https://webtask.io/docs/api_issue.
  * @returns {Sandbox} A {@see Sandbox} instance whose url, token and container were derived from the given webtask token.
@@ -1068,7 +1068,7 @@ Sandbox.fromToken = function (token, options) {
  * Create a Sandbox instance
  *
  * @param {Object} options - The options for creating the Sandbox instance.
- * @param {String} [options.url] - The url of the webtask cluster. Defaults to the public 'webtask.it.auth0.com' cluster.
+ * @param {String} [options.url] - The url of the webtask cluster. Defaults to the public 'sandbox.auth0-extend.com' cluster.
  * @param {String} options.container - The container with which this Sandbox instance should be associated. Note that your Webtask token must give you access to that container or all operations will fail.
  * @param {String} options.token - The Webtask Token. See: https://webtask.io/docs/api_issue.
  * @returns {Sandbox} A {@see Sandbox} instance.
@@ -1082,7 +1082,7 @@ Sandbox.init = function (options) {
     if (typeof options.token !== 'string') throw new Error('A Sandbox instance cannot be created without a token.');
 
     defaults(options, {
-        url: 'https://webtask.it.auth0.com',
+        url: 'https://sandbox.auth0-extend.com',
     });
 
     return new Sandbox(options);

--- a/test/constructors.js
+++ b/test/constructors.js
@@ -61,7 +61,7 @@ lab.experiment('Sandbox.fromToken()', function () {
         expect(sandbox).to.be.an.instanceof(Sandbox);
         expect(sandbox.container).to.equal('test');
         expect(sandbox.token).to.equal(token);
-        expect(sandbox.url).to.equal('https://webtask.it.auth0.com');
+        expect(sandbox.url).to.equal('https://sandbox.auth0-extend.com');
         done();
     });
 });


### PR DESCRIPTION
Updates all references of "https://webtask.it.auth0.com" to "https://sandbox.auth0-extend.com"