### PR TITLE
Update node constraint and webtask-log-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxjs",
-  "version": "4.2.2",
+  "version": "5.0.0",
   "description": "Sandbox node.js code",
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,9 @@
     "url": "https://github.com/auth0/sandboxjs/issues"
   },
   "homepage": "https://github.com/auth0/sandboxjs",
+  "engines": {
+    "node": ">=6"
+  },
   "dependencies": {
     "bluebird": "^2.9.34",
     "jwt-decode": "^2.2.0",
@@ -35,7 +38,7 @@
     "lodash.get": "^4.4.2",
     "randexp": "^0.4.0",
     "superagent": "^3.5.2",
-    "webtask-log-stream": "^2.1.0"
+    "webtask-log-stream": "^3.0.0"
   },
   "devDependencies": {
     "code": "^4.0.0",


### PR DESCRIPTION
Related:
https://github.com/auth0/webtask-log-stream/pull/3
https://github.com/TooTallNate/node-proxy-agent/pull/30

Updates  `webtask-log-stream` (and consequently `proxy-agent`) in order to remove socks deprecation warnings and to enable socks v2.

A new major version is required as moving to a newer version of socks means dropping Node < 6 support.