### PR TITLE
Add support for CSRF token

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -41,7 +41,7 @@ function Sandbox (options) {
     this.csrfToken = options.csrfToken;
     this.onBeforeRequest = []
         .concat(options.onBeforeRequest)
-        .filter(hook => typeof hook === 'function');
+        .filter(function(hook) { return typeof hook === 'function' } );
 
     try {
         var typ = Decode(options.token, { header: true }).typ;
@@ -273,7 +273,7 @@ Sandbox.prototype.createToken = function (options, cb) {
  */
 Sandbox.prototype.issueRequest = function (request, cb) {
     const transformedRequest = this.onBeforeRequest
-        .reduce((request, hook) => {
+        .reduce(function(request, hook) {
             return hook(request, this);
         }, request);
     const promise = Request(transformedRequest);

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -38,6 +38,7 @@ function Sandbox (options) {
     this.url = options.url;
     this.container = options.container;
     this.token = options.token;
+    this.csrfToken = options.csrfToken;
     this.onBeforeRequest = []
         .concat(options.onBeforeRequest)
         .filter(hook => typeof hook === 'function');
@@ -297,7 +298,12 @@ Sandbox.prototype.createTokenRaw = function (claims, options, cb) {
     var request = Superagent
         .post(this.url + '/api/tokens/issue')
         .set('Authorization', 'Bearer ' + this.token)
-        .send(claims);
+
+    if (this.csrfToken) {
+        request.set('X-CSRFToken', this.csrfToken)
+    }
+    
+    request.send(claims);
 
     var promise = this.issueRequest(request)
             .then(function (res) {
@@ -433,7 +439,12 @@ Sandbox.prototype.createWebtask = function (options, cb) {
         var request = Superagent
             .put(url)
             .set('Authorization', 'Bearer ' + this.token)
-            .send(payload)
+            
+        if (this.csrfToken) {
+            request.set('X-CSRFToken', this.csrfToken)
+        }    
+        
+        request.send(payload)
 
         var self = this;
         promise = this.issueRequest(request)
@@ -471,6 +482,10 @@ Sandbox.prototype.removeWebtask = function (options, cb) {
         var request = Superagent
             .del(url)
             .set('Authorization', 'Bearer ' + this.token);
+
+        if (this.csrfToken) {
+            request.set('X-CSRFToken', this.csrfToken)
+        }
 
         promise = this.issueRequest(request)
             .return(true);
@@ -666,7 +681,12 @@ Sandbox.prototype.createCronJob = function (options, cb) {
     var request = Superagent
         .put(this.url + '/api/cron/' + options.container + '/' + options.name)
         .set('Authorization', 'Bearer ' + this.token)
-        .send(payload)
+
+    if (this.csrfToken) {
+        request.set('X-CSRFToken', this.csrfToken)
+    }
+
+    request.send(payload)
         .accept('json');
 
     var promise = this.issueRequest(request)
@@ -691,7 +711,12 @@ Sandbox.prototype.removeCronJob = function (options, cb) {
     var request = Superagent
         .del(this.url + '/api/cron/' + options.container + '/' + options.name)
         .set('Authorization', 'Bearer ' + this.token)
-        .accept('json');
+
+    if (this.csrfToken) {
+        request.set('X-CSRFToken', this.csrfToken)
+    }
+
+    request.accept('json');
 
     var promise = this.issueRequest(request)
         .get('body');
@@ -715,7 +740,12 @@ Sandbox.prototype.setCronJobState = function (options, cb) {
     var request = Superagent
         .put(this.url + '/api/cron/' + options.container + '/' + options.name + '/state')
         .set('Authorization', 'Bearer ' + this.token)
-        .send({
+
+    if (this.csrfToken) {
+        request.set('X-CSRFToken', this.csrfToken)
+    }
+
+    request.send({
             state: options.state,
         })
         .accept('json');
@@ -899,7 +929,12 @@ Sandbox.prototype.revokeToken = function (token, cb) {
     var request = Superagent
         .post(this.url + '/api/tokens/revoke')
         .set('Authorization', 'Bearer ' + this.token)
-        .query({ token: token });
+
+    if (this.csrfToken) {
+        request.set('X-CSRFToken', this.csrfToken)
+    }
+
+    request.query({ token: token });
 
     var promise = this.issueRequest(request);
 
@@ -938,6 +973,10 @@ Sandbox.prototype.ensureNodeModules = function (options, cb) {
         .post(this.url + '/api/env/node/modules')
         .send({ modules: options.modules })
         .set('Authorization', 'Bearer ' + this.token);
+    
+    if (this.csrfToken) {
+        request.set('X-CSRFToken', this.csrfToken)
+    }
 
     if (options.reset) {
         request.query({ reset: 1 });
@@ -984,6 +1023,10 @@ Sandbox.prototype.updateStorage = function (storage, options, cb) {
             .send(obj)
             .set('Authorization', 'Bearer ' + this.token)
             .accept('json');
+
+        if (this.csrfToken) {
+            request.set('X-CSRFToken', this.csrfToken)
+        }
 
         promise = this.issueRequest(request)
             .get('body');

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -43,6 +43,11 @@ function Sandbox (options) {
         .concat(options.onBeforeRequest)
         .filter(function(hook) { return typeof hook === 'function' } );
 
+    this.headers = { 'Authorization': 'Bearer ' + this.token};
+    if (this.csrfToken) {
+        this.headers['X-CSRFToken'] = this.csrfToken;
+    }
+
     try {
         var typ = Decode(options.token, { header: true }).typ;
 
@@ -272,6 +277,7 @@ Sandbox.prototype.createToken = function (options, cb) {
  * @returns {Promise} - A promise representing the fulfillment of the request
  */
 Sandbox.prototype.issueRequest = function (request, cb) {
+    request.set(this.headers)
     const transformedRequest = this.onBeforeRequest
         .reduce(function(request, hook) {
             return hook(request, this);
@@ -297,11 +303,6 @@ Sandbox.prototype.createTokenRaw = function (claims, options, cb) {
     }
     var request = Superagent
         .post(this.url + '/api/tokens/issue')
-        .set('Authorization', 'Bearer ' + this.token)
-
-    if (this.csrfToken) {
-        request.set('X-CSRFToken', this.csrfToken)
-    }
     
     request.send(claims);
 
@@ -364,7 +365,6 @@ Sandbox.prototype.getWebtask = function (options, cb) {
             + (options.container || this.container) + '/' + options.name;
         var request = Superagent
             .get(url)
-            .set('Authorization', 'Bearer ' + this.token)
             .accept('json');
         var self = this;
 
@@ -437,12 +437,7 @@ Sandbox.prototype.createWebtask = function (options, cb) {
         if (options.meta) payload.meta = options.meta;
         if (options.host) payload.host = options.host;
         var request = Superagent
-            .put(url)
-            .set('Authorization', 'Bearer ' + this.token)
-            
-        if (this.csrfToken) {
-            request.set('X-CSRFToken', this.csrfToken)
-        }    
+            .put(url)   
         
         request.send(payload)
 
@@ -481,11 +476,6 @@ Sandbox.prototype.removeWebtask = function (options, cb) {
             + (options.container || this.container) + '/' + options.name;
         var request = Superagent
             .del(url)
-            .set('Authorization', 'Bearer ' + this.token);
-
-        if (this.csrfToken) {
-            request.set('X-CSRFToken', this.csrfToken)
-        }
 
         promise = this.issueRequest(request)
             .return(true);
@@ -620,7 +610,6 @@ Sandbox.prototype.listWebtasks = function (options, cb) {
         + (options.container || this.container);
     var request = Superagent
         .get(url)
-        .set('Authorization', 'Bearer ' + this.token)
         .accept('json');
 
     if (options.offset) request.query({ offset: options.offset });
@@ -680,11 +669,6 @@ Sandbox.prototype.createCronJob = function (options, cb) {
 
     var request = Superagent
         .put(this.url + '/api/cron/' + options.container + '/' + options.name)
-        .set('Authorization', 'Bearer ' + this.token)
-
-    if (this.csrfToken) {
-        request.set('X-CSRFToken', this.csrfToken)
-    }
 
     request.send(payload)
         .accept('json');
@@ -710,11 +694,6 @@ Sandbox.prototype.removeCronJob = function (options, cb) {
 
     var request = Superagent
         .del(this.url + '/api/cron/' + options.container + '/' + options.name)
-        .set('Authorization', 'Bearer ' + this.token)
-
-    if (this.csrfToken) {
-        request.set('X-CSRFToken', this.csrfToken)
-    }
 
     request.accept('json');
 
@@ -739,11 +718,6 @@ Sandbox.prototype.setCronJobState = function (options, cb) {
 
     var request = Superagent
         .put(this.url + '/api/cron/' + options.container + '/' + options.name + '/state')
-        .set('Authorization', 'Bearer ' + this.token)
-
-    if (this.csrfToken) {
-        request.set('X-CSRFToken', this.csrfToken)
-    }
 
     request.send({
             state: options.state,
@@ -776,7 +750,6 @@ Sandbox.prototype.listCronJobs = function (options, cb) {
 
     var request = Superagent
         .get(this.url + '/api/cron/' + options.container)
-        .set('Authorization', 'Bearer ' + this.token)
         .accept('json');
 
     if (options.offset) request.query({ offset: options.offset });
@@ -808,7 +781,6 @@ Sandbox.prototype.getCronJob = function (options, cb) {
 
     var request = Superagent
         .get(this.url + '/api/cron/' + options.container + '/' + options.name)
-        .set('Authorization', 'Bearer ' + this.token)
         .accept('json');
 
     var promise = this.issueRequest(request)
@@ -835,7 +807,6 @@ Sandbox.prototype.getCronJobHistory = function (options, cb) {
 
     var request = Superagent
         .get(this.url + '/api/cron/' + options.container + '/' + options.name + '/history')
-        .set('Authorization', 'Bearer ' + this.token)
         .accept('json');
 
     if (options.offset) request.query({offset: options.offset});
@@ -882,7 +853,6 @@ Sandbox.prototype.inspectToken = function (options, cb) {
     var request = Superagent
         .get(this.url + '/api/tokens/inspect')
         .query({ token: options.token })
-        .set('Authorization', 'Bearer ' + this.token)
         .accept('json');
 
     if (options.decrypt) request.query({ decrypt: options.decrypt });
@@ -928,11 +898,6 @@ Sandbox.prototype.inspectWebtask = function (options, cb) {
 Sandbox.prototype.revokeToken = function (token, cb) {
     var request = Superagent
         .post(this.url + '/api/tokens/revoke')
-        .set('Authorization', 'Bearer ' + this.token)
-
-    if (this.csrfToken) {
-        request.set('X-CSRFToken', this.csrfToken)
-    }
 
     request.query({ token: token });
 
@@ -972,11 +937,6 @@ Sandbox.prototype.ensureNodeModules = function (options, cb) {
     var request = Superagent
         .post(this.url + '/api/env/node/modules')
         .send({ modules: options.modules })
-        .set('Authorization', 'Bearer ' + this.token);
-    
-    if (this.csrfToken) {
-        request.set('X-CSRFToken', this.csrfToken)
-    }
 
     if (options.reset) {
         request.query({ reset: 1 });
@@ -1021,12 +981,7 @@ Sandbox.prototype.updateStorage = function (storage, options, cb) {
         var request = Superagent
             .put(this.url + '/api/webtask/' + (options.container || this.container) + '/' + options.name + '/data')
             .send(obj)
-            .set('Authorization', 'Bearer ' + this.token)
             .accept('json');
-
-        if (this.csrfToken) {
-            request.set('X-CSRFToken', this.csrfToken)
-        }
 
         promise = this.issueRequest(request)
             .get('body');
@@ -1056,7 +1011,6 @@ Sandbox.prototype.getStorage = function (options, cb) {
     else {
         var request = Superagent
             .get(this.url + '/api/webtask/' + (options.container || this.container) + '/' + options.name + '/data')
-            .set('Authorization', 'Bearer ' + this.token)
             .accept('json');
 
         promise = this.issueRequest(request)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash.defaultsdeep": "^4.6.0",
     "lodash.foreach": "^4.5.0",
     "lodash.get": "^4.4.2",
-    "randexp": "^0.4.0",
+    "randexp": "0.4.0",
     "superagent": "^3.5.2",
     "webtask-log-stream": "^3.0.0"
   },


### PR DESCRIPTION
### Description

This PR implements support for passing in a `csrfToken` in the options for `Sandbox`. The provided CSRF token is added as a header in requests. 

### References

https://auth0team.atlassian.net/browse/DXEX-537

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
