### PR TITLE
Feat: add support for `options.logEndpoint`

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -37,6 +37,7 @@ function Sandbox (options) {
 
     this.url = options.url;
     this.container = options.container;
+    this.logEndpoint = options.logEndpoint;
     this.token = options.token;
     this.csrfToken = options.csrfToken;
     this.onBeforeRequest = []
@@ -327,11 +328,12 @@ Sandbox.prototype.createTokenRaw = function (claims, options, cb) {
  */
 Sandbox.prototype.createLogStream = function (options) {
     if (!options) options = {};
-
-    var url = this.url + '/api/logs/tenant/'
+    const logEndpoint = this.logEndpoint || '/api/logs/tenant/';
+    var url = this.url + logEndpoint
         + (options.container || this.container)
-        + '?key=' + encodeURIComponent(this.token);
-
+    if (this.token) {
+        url += '?key=' + encodeURIComponent(this.token);
+    }
     return LogStream(url);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxjs",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Sandbox node.js code",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

Add support for `options.logEndpoint`, the webtask log stream API endpoint. Defaults to `/api/logs/tenant`. 

This is used to allow clients using the Management API Webtask Proxy to specify that requests for logs should go to a specific endpoint rather than `/api/logs`, since Manage has a conflicting endpoint.

### References
https://auth0team.atlassian.net/browse/DXEX-537

### Testing
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
